### PR TITLE
feat: Create a minimal working prototype

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,342 @@
+Whistle
+=======
+
+``whistle`` is a utility to automatically download Ubuntu WSL images, create new WSL2
+instances and provision them.
+
+.. contents:: **Outline**
+
+How to use
+----------
+
+1. Download this repository as a zip file and extract it into any directory on your
+   local machine.
+
+2. Open a powershell terminal and navigate to that directory.
+
+.. pull-quote:: \:one: **ONE-TIME SETUP**
+
+   Install WSL with the following command, then restart your computer.
+
+   .. code-block:: terminal
+
+      wsl --install --no-distribution
+
+3. Run the following command:
+
+   .. code-block:: powershell
+
+      PowerShell -ExecutionPolicy Bypass -File .\whistle.ps1 --WslDistroName whistleblower
+
+   This creates a new WSL2 instance of the default Linux flavour and release with only
+   the core setup bundles installed. See the `Parameters`_ section below to install
+   additional optional bundles and for other customizations.
+
+   .. pull-quote:: \:bangbang: **IMPORTANT**
+
+      The script also creates a standard user on the WSL2 instance. By default, the
+      username and password are the same as the instance name.
+
+   .. pull-quote:: \:bulb: **TIP**
+
+      To create another instance, run the command again with a different instance name.
+
+   .. pull-quote:: \:drum: **ATTENTION**
+
+      PowerShell's `execution policy <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies>`_
+      prevents execution of unsigned scripts. The ``-ExecutionPolicy Bypass`` in the
+      above command bypasses it to enable ``whistle.ps1`` to be executed. I do not want
+      to buy a code-signing certificate, but I will easily change my mind if I receive
+      enough sponsorship.
+
+Parameters
+----------
+
+.. list-table:: Parameters
+   :header-rows: 1
+
+   * - **⠀⠀⠀Parameter⠀⠀⠀**
+     - **Description**
+     - **Examples**
+     - **Default**
+     - **Notes**
+   * - ``-WslDistroName``
+     - Name for your new WSL2 instance.
+     - ``whistleblower``, ``heavens-arena``
+     - ``whistleblower``
+     -
+   * - ``-ReleaseName``
+     - Ubuntu release name.
+     - ``noble``, ``jammy``
+     - ``noble``
+     - Available releases at https://cloud-images.ubuntu.com/wsl/.
+   * - ``-ReleaseTag``
+     - Release tag of the WSL2 image to download.
+     - ``current``, ``20241008``
+     - ``current``
+     - Available tags inside the chosen release directory at the above page.
+   * - ``-ReleaseArch``
+     - Architecture of the WSL2 image.
+     - ``amd64``, ``arm64``
+     - ``amd64``
+     -
+   * - ``-SetupArgs``
+     - Arguments for the setup script ``whistle.bash``.
+     - ``"'-h'"``, ``"'-b python3'"``, ``"'-u dragondive -b copy-ssh-keys'"``
+     - ``""``
+     - This needs to be enclosed in *both* double quotes and single quotes.
+       Run with ``"'-h'"`` for the full description of the supported arguments.
+
+Contributor Documentation
+-------------------------
+
+``whistle`` consists of two scripts:
+
+1. The powershell script ``whistle.ps1`` that downloads the WSL2 image and creates an
+   instance of it.
+2. The bash script ``whistle.bash`` that provisions the installed WSL2 instance.
+
+These scripts are further described in the below sections.
+
+powershell script ``whistle.ps1``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This script performs the following main operations:
+
+1. Download the user-specified WSL2 image: As an optimization, the images are cached to
+   a standard location which avoids redownloading when the script is run multiple times.
+2. Import the WSL2 image to create a new instance of it.
+3. Install VS Code: It is more convenient to install it on Windows and further configure
+   it from WSL2 than installing it directly inside WSL2.
+4. Run the provisioning script ``whistle.bash`` inside the newly created WSL2 instance.
+
+bash script ``whistle.bash``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This script performs various installation and configuration steps. It first executes as
+the root user and then as a standard user. While running as the root user, it also
+creates the standard user.
+
+The installation and configuration steps are organized into setup bundles. Setup bundles
+are of two types:
+
+1. **core bundles**: These are always executed as they perform essential installation
+   and configuration.
+2. **optional bundles**: These are executed only if requested.
+
+How to define a new setup bundle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This section describes the steps required to define a new setup bundle, which is given
+the hypothetical name ``watchdog`` for clarity of understanding. Perform the following
+modifications in the ``whistle.bash`` file:
+
+1. Decide if ``watchdog`` is a core bundle or an optional bundle. Accordingly, add an
+   item to the ``EXECUTE_BUNDLE`` associative array.
+
+   *Core bundle*
+
+   .. code-block:: bash
+      :caption: watchdog is a core bundle
+
+      EXECUTE_BUNDLE=(
+      ...
+          [watchdog]=1
+      )
+
+   *Optional bundle*
+
+   .. code-block:: bash
+      :caption: watchdog is an optional bundle
+
+      EXECUTE_BUNDLE=(
+      ...
+          [watchdog]=0
+      )
+
+2. Determine if the ``watchdog`` bundle should be executed as the root user or as
+   the standard user. This determines the placement of its installation and
+   configuration steps block (described in the next step). You may also execute it in
+   two parts, first as the root user and then as the standard user.
+
+   * To execute it as the root user, the installation and configuration block needs to
+     be inside the following ``if`` ... ``fi`` block:
+
+     .. code-block:: bash
+        :caption: Execute watchdog as the root user
+
+        if [[ $EUID -eq 0 ]]; then
+        ...
+        # watchdog's installation and configuration block (described in the next step)
+        # needs to go here.
+        ...
+        fi
+
+   * To execute it as the standard user, the installation and configuration block needs
+     to be outside *and* after the above-mentioned ``if`` ... ``fi`` block.
+
+     .. pull-quote:: \:bulb: **TIP**
+
+        To preserve any environment variables when the script switches from the root
+        user to the standard user, append it to the ``--preserve-env`` argument of the
+        ``exec sudo`` command:
+
+        .. code-block:: bash
+           :caption: preserving environment variables when switching to the standard user
+           :highlight-lines: 2
+
+           echo "Switching to the standard user for further configuration..."
+           exec sudo \
+           --preserve-env=USERNAME,PATH,WSL_DISTRO_NAME \
+           --login \
+           --user "$DEFAULT_USER" \
+           "$(realpath $0)" "${ARGUMENTS[@]}"
+
+3. Define the installation and configuration steps for ``watchdog`` in
+   an ``if`` ... ``fi`` block:
+
+   .. code-block:: bash
+      :caption: installation and configuration steps for the watchdog bundle
+
+      if [ "${EXECUTE_BUNDLE[watchdog]}" -eq 1 ]; then
+          echo "Installing watchdog..."
+
+          # Add installation and configuration steps for watchdog here
+          sudo apt-get install -yq example-watchdog
+          export PATH="$PATH:/usr/bin/example-watchdog" | tee -a /home/$DEFAULT_USER/.profile
+          ...
+      fi
+
+   * **VS Code extensions** (optional): Suitable VS Code extensions may be
+     specified for installation in the installation and configuration block:
+
+     .. code-block:: bash
+        :caption: Specifying VS Code extensions
+
+        VSCODE_EXTENSIONS+=(\
+            "whistleblower.watchdog.bark", \
+            "whistleblower.watchdog.bite" \
+        )
+
+4. Update the ``display_help()`` function mentioning the ``watchdog`` setup bundle,
+   with additional explanation if necessary.
+
+Frequently Asked Questions
+--------------------------
+
+.. pull-quote:: \:question: **Question**
+
+   Why doesn't ``whistle`` have a setup bundle for *<a language or technology that
+   I use or prefer>*?
+
+.. pull-quote:: \:speech_balloon: **Answer**
+
+   The current ``whistle`` is a minimal working utility. I released it so that it
+   grows with developer community's contributions. You are welcome to contribute more
+   setup bundles. Refer `Contributor Documentation`_ for more information. I also plan
+   to add more setup bundles in the future.
+
+|
+
+.. pull-quote:: \:question: **Question**
+
+   Can the *X* setup bundle include tool *Y* or exclude tool *Z* because that's my
+   team's setup at work?
+
+.. pull-quote:: \:speech_balloon: **Answer**
+
+   Sure! You may modify any setup bundle in ``whistle.bash`` to suit your preference.
+   Please consider contributing your changes back to ``whistle`` if it would be useful
+   to other developers.
+
+|
+
+.. pull-quote:: \:question: **Question**
+
+   I don't like VS Code, I prefer using the *X* IDE instead. Why does ``whistle`` force
+   me to use VS Code?
+
+.. pull-quote:: \:speech_balloon: **Answer**
+
+   You are not forced to use VS Code. You can modify the ``whistle`` script to install
+   and configure your preferred IDE. You can even get rid of the VS Code setup.
+
+   ``whistle`` started as my personal utility project. I regularly use many programming
+   languages, such as Python, Java, C++, Rust and Go. I also frequently write scripts
+   in bash and powershell. Besides, I routinely work with multiple markup and
+   configuration formats, such as Markdown, RST, CSV, TOML, YAML, INI and JSON.
+   A general-purpose IDE is more convenient even if it lacks some features of the
+   language-specific IDEs.
+
+   VS Code works seamlessly with minimal hassles on Windows, WSL2 running on Windows,
+   *and* docker containers running inside that WSL2. Other IDEs have not offered me a
+   smooth experience in this area.
+
+|
+
+.. pull-quote:: \:question: **Question**
+
+   Can I use ``whistle`` to install the *X* flavour of Linux instead of Ubuntu?
+
+.. pull-quote:: \:speech_balloon: **Answer**
+
+   Yes, certainly. You are free to enhance ``whistle`` to make the Linux flavour
+   configurable. Please consider contributing your enhancement back to the community
+   as well.
+
+|
+
+.. pull-quote:: \:question: **Question**
+
+   Why do you want the user to modify your code to get it working for them? Isn't that
+   a poor design or even an anti-pattern?
+
+.. pull-quote:: \:speech_balloon: **Answer**
+
+   For any general-purpose utliity, that would indeed be a poor design. However,
+   ``whistle`` is meant primarily for developers. Developers are expected to be able to
+   adapt a powershell and a bash script, even with no prior scripting experience, so I do
+   consider this a problem.
+
+   Moreover, it is not practical to create a configuration script that fits everyone's
+   needs exactly. However, if there is sufficient interest from the community, I would
+   consider refactoring to configure the setup bundles through a YAML or TOML
+   configuration file.
+
+|
+
+.. pull-quote:: \:question: **Question**
+
+   Why do you consider docker to be a core bundle?
+
+.. pull-quote:: \:speech_balloon: **Answer**
+
+   Docker is the most commonly used containerization technology. Personally, I strongly
+   prefer using tools through their docker container instead of the local installation.
+   Local installation often leads to mess and clutter, along with the occasional
+   dependency hells. Moreover, trying out and comparing various versions of tools is a
+   breeze with docker.
+
+|
+
+.. pull-quote:: \:question: **Question**
+
+   What was your motivation to create ``whistle``?
+
+.. pull-quote:: \:speech_balloon: **Answer**
+
+   We humans have created many great things in this world. We have also created the
+   Windows operating system, which many developers end up using instead of Linux.
+   This has also led to the creation of the Windows Subsystem for Linux (WSL).
+
+   The `standard approach <https://learn.microsoft.com/en-us/windows/wsl/install>`_ of
+   installing only one instance of a WSL release was highly limiting for a lot of my
+   development work. I discovered the lesser known option of importing a WSL image,
+   which could be used to create multiple instances. However, that still requires some
+   configuration to be usable. There were also several steps I performed repeatedly to
+   setup my WSL instances. The logical next step was to automate.
+
+   Having enjoyed the flexibility of multiple WSL instances—created with a single
+   command line invocation—and saving hundreds of hours in the process, I decided to
+   share my work with the developer community, for the benefit of developers who need
+   to use Windows.

--- a/whistle.bash
+++ b/whistle.bash
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+display_help()
+{
+cat << EOF
+Usage: whistle.bash [OPTION]...
+
+-h, --help
+    Display this help message and exit
+
+-u, --username <username>
+    Create a local user <username> in the WSL2 instance and set it as the default user.
+    Also prompts to set the password for the user.
+
+    If not specified, the WSL2 distro name will be the default username and password.
+
+-b, --setup-bundles [bundles,...]
+    Comma-separated list of setup bundles to be executed. Some setup bundles are
+    considered core bundles and will always be executed.
+
+    Usually the setup bundles will install the respective application, some useful
+    utilities, and perform standard configurations. Additional information about
+    specific setup bundles is described below.
+
+Available setup bundles:
+    - python3
+    - copy-ssh-keys
+        Copies ssh keys from Windows to WSL2 and sets the correct permissions.
+    - docker [core bundle]
+    - git [core bundle]
+    - utils [core bundle]
+
+EOF
+}
+
+ARGUMENTS=("$@")
+options=$(getopt -l \
+    "help,username:,setup-bundles:", \
+    -o "h,u:,b:" -- \
+    "${ARGUMENTS[@]}")
+eval set -- "$options"
+
+declare -A EXECUTE_BUNDLE
+EXECUTE_BUNDLE=(
+    [python3]=0
+    [copy-ssh-keys]=0
+    [docker]=1
+    [git]=1
+    [utils]=1
+)
+
+while true; do
+    case "$1" in
+    -h|--help)
+        display_help
+        exit 0
+        ;;
+    -u|--username)
+        shift
+        export DEFAULT_USER="$1"
+        ;;
+    -b|--setup-bundles)
+        shift
+        IFS=',' read -ra BUNDLES <<< "$1"
+        for BUNDLE in "${BUNDLES[@]}"; do
+            EXECUTE_BUNDLE["$BUNDLE"]=1
+        done
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *)
+        echo "Invalid option: $1"
+        display_help
+        exit 1
+        ;;
+    esac
+shift
+done
+
+EXECUTE_BUNDLE_MESSAGE="Executing setup bundles: "
+for bundle in "${!EXECUTE_BUNDLE[@]}"; do
+    if [[ ${EXECUTE_BUNDLE["$bundle"]} -eq 1 ]]; then
+        EXECUTE_BUNDLE_MESSAGE+="$bundle "
+    fi
+done
+echo "$EXECUTE_BUNDLE_MESSAGE"
+
+VSCODE_EXTENSIONS=(\
+    "ms-vscode-remote.remote-containers" \
+    "ms-vscode-remote.remote-ssh" \
+    "ms-vscode-remote.remote-ssh-edit" \
+    "ms-vscode-remote.remote-wsl" \
+    "ms-vscode.remote-explorer" \
+    "ms-vscode-remote.remote-wsl" \
+    "ms-vscode-remote.vscode-remote-extensionpack" \
+    "vscode-icons-team.vscode-icons" \
+    "shd101wyy.markdown-preview-enhanced" \
+    "redhat.vscode-yaml" \
+    "tamasfe.even-better-toml" \
+    "bierner.emojisense" \
+)
+
+if [[ $EUID -eq 0 ]]; then
+    echo "Executing setup as the root user..."
+
+    echo "Creating a new default standard user..."
+    if [[ -z "$DEFAULT_USER" ]]; then
+        DEFAULT_USER=$WSL_DISTRO_NAME
+        DEFAULT_USER_PASSWORD=$WSL_DISTRO_NAME
+        printf "%b" "No username specified. Using the WSL2 distro name "\
+        "'$DEFAULT_USER' as the default username and password.\n"
+    fi
+
+    if [[ -z "$DEFAULT_USER_PASSWORD" ]]; then
+        read -esp \
+            "Enter password for user '$DEFAULT_USER': " DEFAULT_USER_PASSWORD
+    fi
+    ENCRYPTED_PASSWORD=$(echo $DEFAULT_USER_PASSWORD | openssl passwd -1 -stdin)
+
+    useradd \
+        --create-home \
+        --shell /bin/bash \
+        --user-group --groups adm,sudo \
+        --password "$ENCRYPTED_PASSWORD" \
+        $DEFAULT_USER
+
+    ### Set the default user and enable systemd ###
+    printf "%b" \
+    "[user]\n" \
+    "default=$DEFAULT_USER\n" \
+    "[boot]\n" \
+    "systemd=true\n" \
+        | tee /etc/wsl.conf
+
+    # Fix the exec format error to enable running Windows applications from WSL2.
+    # credit: https://github.com/microsoft/WSL/issues/8952#issuecomment-1568212651
+    sh -c 'echo :WSLInterop:M::MZ::/init:PF > /usr/lib/binfmt.d/WSLInterop.conf'
+    systemctl restart systemd-binfmt
+
+    if [[ ${EXECUTE_BUNDLE[docker]} -eq 1 ]]; then
+        echo "Installing docker..."
+
+        for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker \
+                   containerd runc;
+        do
+            sudo apt-get remove -yq $pkg 2> /dev/null
+        done
+
+        apt-get update -yq
+        apt-get install -yq ca-certificates curl gnupg
+        install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+            | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        chmod a+r /etc/apt/keyrings/docker.gpg
+
+        echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+            | tee /etc/apt/sources.list.d/docker.list > /dev/null
+        apt-get update -yq
+        apt-get install -yq docker-ce docker-ce-cli containerd.io \
+                            docker-buildx-plugin docker-compose-plugin
+
+        usermod -aG docker $DEFAULT_USER # enables the user to run docker without sudo.
+
+        VSCODE_EXTENSIONS+=(\
+            "ms-azuretools.vscode-docker" \
+        )
+    fi
+
+    if [[ ${EXECUTE_BUNDLE[git]} -eq 1 ]]; then
+        echo "Installing git..."
+        sudo apt-get install -yq git-all gitg hub kdiff3
+
+        VSCODE_EXTENSIONS+=(\
+            "eamodio.gitlens" \
+            "github.vscode-pull-request-github" \
+            "github.remotehub" \
+            "github.vscode-github-actions" \
+            "github.codespaces" \
+        )
+    fi
+
+    if [[ ${EXECUTE_BUNDLE[utils]} -eq 1 ]]; then
+        echo "Installing useful utilities..."
+        sudo apt-get install -yq neovim-qt terminator pandoc
+    fi
+
+    if [[ ${EXECUTE_BUNDLE[python3]} -eq 1 ]]; then
+        echo "Installing Python 3..."
+        sudo apt-get install -yq python3 python3-pip python3-venv python3-wheel
+
+        POETRY_HOME=/home/$DEFAULT_USER/.local
+        curl -sSL https://install.python-poetry.org | POETRY_HOME=$POETRY_HOME python3 -
+        printf "%b" \
+        "export PATH=\"\$PATH:$POETRY_HOME\"\n" \
+            | tee -a /home/$DEFAULT_USER/.profile
+
+        VSCODE_EXTENSIONS+=(\
+            "ms-python.python" \
+            "ms-python.debugpy" \
+            "ms-python.isort" \
+        )
+    fi
+
+    echo "Switching to the standard user for further configuration..."
+    exec sudo \
+        --preserve-env=USERNAME,PATH,WSL_DISTRO_NAME \
+        --login \
+        --user "$DEFAULT_USER" \
+        "$(realpath $0)" "${ARGUMENTS[@]}"
+fi
+
+echo "Running configuration as the standard user..."
+
+if [[ ${EXECUTE_BUNDLE[copy-ssh-keys]} -eq 1 ]]; then
+    echo "Copying ssh keys from Windows to WSL2..."
+    mkdir -p ~/.ssh && cp -v /mnt/c/Users/$USERNAME/.ssh/id_* ~/.ssh
+    find ~/.ssh -type f -exec grep -rlE -- '-----BEGIN.*PRIVATE KEY-----' {} + \
+        | xargs -I {} chmod -v 600 {} # private key files need to have permission 600
+fi
+
+echo "Installing vscode extensions..."
+VSCODE_EXTENSIONS_INSTALL_COMMAND="code --force --verbose "
+for extension in "${VSCODE_EXTENSIONS[@]}"; do
+    VSCODE_EXTENSIONS_INSTALL_COMMAND+="--install-extension ${extension} "
+done
+eval "$VSCODE_EXTENSIONS_INSTALL_COMMAND"
+
+echo "WSL2 setup completed!"
+echo \
+"You may now start using your WSL2 instance with the following command:
+
+    wsl -d $WSL_DISTRO_NAME
+"
+
+exit 0

--- a/whistle.ps1
+++ b/whistle.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+    Download, create and provision an Ubuntu WSL2 instance.
+.DESCRIPTION
+    This script downloads a user-specified Ubuntu WSL2 image, then creates and
+    provisions a WSL2 instance using the downloaded image.
+.PARAMETER WslDistroName
+    User-chosen name for the WSL2 instance to be created.
+
+    Example values: whistleblower, heavens-arena
+    Default: whistleblower
+.PARAMETER ReleaseName
+    Ubuntu release name. For available WSL releases, see the Ubuntu WSL images page at
+    https://cloud-images.ubuntu.com/wsl/
+
+    Example values: noble, jammy
+    Default: noble
+.PARAMETER ReleaseTag
+    Ubuntu release tag. Available release tags are found inside the directory of the
+    specified release on the Ubuntu WSL images page.
+
+    Example values: current, 20241008
+    Default: current
+.PARAMETER ReleaseArch
+    Architecture of the WSL image to be downloaded.
+
+    Example values: amd64, arm64
+    Default: amd64
+.PARAMETER SetupArgs
+    Arguments for the setup script `whistle.bash`.
+    Due to powershell's parsing limitations, this needs to be enclosed in _both_
+    double quotes and single quotes.
+    Use "'-h'" as the argument to see the arguments documentation.
+
+    Example values: "'-h'", "'-b python3'", "'-u dragondive -b copy-ssh-keys'"
+    Default: ""
+#>
+param
+(
+    [Parameter(HelpMessage="User-chosen name for the WSL2 instance to be created.")]
+    [string]$WslDistroName = "whistleblower",
+
+    [Parameter(HelpMessage="Ubuntu release name.")]
+    [string]$ReleaseName = "noble",
+
+    [Parameter(HelpMessage="Ubuntu release tag.")]
+    [string]$ReleaseTag = "current",
+
+    [Parameter(HelpMessage="Architecture of the WSL image to be downloaded.")]
+    [string]$ReleaseArch = "amd64",
+
+    [Parameter(HelpMessage="Arguments for the setup script whistle.bash")]
+    [string]$SetupArgs = ""
+)
+
+$WslUbuntuUrl = "https://cloud-images.ubuntu.com/wsl"
+$ImageName = "ubuntu-$ReleaseName-wsl-$ReleaseArch-ubuntu.rootfs.tar.gz"
+
+$ImageUrl = "$WslUbuntuUrl/$ReleaseName/$ReleaseTag/$ImageName"
+$SaveDir = "$env:LOCALAPPDATA/whistle"
+$ImagePath = "$SaveDir/$ImageName"
+
+[System.IO.Directory]::CreateDirectory($SaveDir) | Out-Null
+if (!(Test-Path($ImagePath)))
+{
+    Write-Host "Downloading WSL Ubuntu image '$ReleaseName' to '$SaveDir'..."
+    (New-Object Net.WebClient).DownloadFile($ImageUrl, $ImagePath)
+}
+else
+{
+    Write-Host "WSL Ubuntu image '$ReleaseName' already exists, skipping download."
+}
+
+$WslPackagesDir = "$env:LOCALAPPDATA/Packages/WSL"
+[System.IO.Directory]::CreateDirectory($WslPackagesDir) | Out-Null
+wsl --import $WslDistroName $WslPackagesDir/$WslDistroName $ImagePath
+if ($LASTEXITCODE -ne 0)
+{
+    throw "Failed to import WSL Ubuntu image '$ReleaseName' to '$WslDistroName'."
+}
+Write-Host "Successfully imported WSL Ubuntu image '$ReleaseName' to '$WslDistroName'."
+
+# Install vscode on Windows because we will use inside WSL2. This is more convenient
+# and flexible than the direct installation inside WSL2.
+winget install --exact --verbose --accept-package-agreements --accept-source-agreements `
+--version 1.93.0 --force <# prevent "upgrade" to 1.94.0 due to this bug: https://github.com/microsoft/vscode/issues/230584 #> `
+--id Microsoft.VisualStudioCode
+
+$ScriptDir = "$env:TEMP"
+Copy-Item -Path $(Join-Path $PWD "whistle.bash") -Destination $ScriptDir
+Set-Location -Path $ScriptDir
+wsl --distribution $WslDistroName -- bash whistle.bash $SetupArgs


### PR DESCRIPTION
This commit creates a minimal working prototype of the `whistle` utility. This enables the following features:

* With a single command, automatically download WSL2 image, create an instance from it, and provision the instance.
* Define the overarching structure for the provisioning script, consisting two phases: first as the root user and then as the standard user.
* Organize the provisioning into setup bundles, further categorized into core bundles and optional bundles.
* Enable automatic installation of VS Code and the VS Code extensions specified in each setup bundle.
* A README document that explains how to use the utility, as well as how to contribute to extend it.

fixes: #1