### PR TITLE
fix: ensure WSL2 instance starts as the standard user after the provisioning

### DIFF
--- a/whistle.ps1
+++ b/whistle.ps1
@@ -90,3 +90,4 @@ $ScriptDir = "$env:TEMP"
 Copy-Item -Path $(Join-Path $PWD "whistle.bash") -Destination $ScriptDir
 Set-Location -Path $ScriptDir
 wsl --distribution $WslDistroName -- bash -c "./whistle.bash $SetupArgs"
+wsl --terminate $WslDistroName


### PR DESCRIPTION


Explicitly terminate the WSL2 instance in the wrapper script `whistle.ps1`. Doing this ensures that the root user is properly logged out after the provisioning script completes. Starting the WSL2 instance afterwards will therefore login the standard user which was conigured in the `/etc/wsl.conf`.

fixes: #18