### PR TITLE
workaround: remove vscode version pin

### DIFF
--- a/whistle.ps1
+++ b/whistle.ps1
@@ -90,7 +90,6 @@ Write-Host "Successfully imported WSL Ubuntu image '$ReleaseName' to '$WslDistro
 # Install vscode on Windows because we will use inside WSL2. This is more convenient
 # and flexible than the direct installation inside WSL2.
 winget install --exact --verbose --accept-package-agreements --accept-source-agreements `
---version 1.93.0 --force <# prevent "upgrade" to 1.94.0 due to this bug: https://github.com/microsoft/vscode/issues/230584 #> `
 --id Microsoft.VisualStudioCode
 
 $ScriptDir = "$env:TEMP"


### PR DESCRIPTION
The version pin workaround was created due to this vscode bug: https://github.com/microsoft/vscode/issues/230584. The bug has been fixed, hence the workaround is now removed.

fixes: #22