### PR TITLE
feat: Describe `whistle.bash` setup arguments in `whistle.ps1` help

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,28 +9,37 @@ instances and provision them.
 How to use
 ----------
 
-1. Download this repository as a zip file and extract it into any directory on your
-   local machine.
-
-2. Open a powershell terminal and navigate to that directory.
-
 .. pull-quote:: \:one: **ONE-TIME SETUP**
 
-   Install WSL with the following command, then restart your computer.
+   1. Install WSL with the below command
 
    .. code-block:: terminal
 
       wsl --install --no-distribution
 
+   2. Restart your computer.
+
+1. Download this repository as a zip file and extract it to any directory on your Windows machine.
+2. Open a powershell terminal and navigate to that directory.
+
+.. pull-quote:: \:bulb: **TIP**
+
+   Run the below command to read the help message. Determine the setup bundles you want to install
+   on the new WSL2 instance and any other customizations you want to make.
+
+   .. code-block:: powershell
+
+      PowerShell -ExecutionPolicy Bypass -File .\whistle.ps1 -Help
+
 3. Run the following command:
 
    .. code-block:: powershell
 
-      PowerShell -ExecutionPolicy Bypass -File .\whistle.ps1 --WslDistroName whistleblower
+      PowerShell -ExecutionPolicy Bypass -File .\whistle.ps1
 
-   This creates a new WSL2 instance of the default Linux flavour and release with only
-   the core setup bundles installed. See the `Parameters`_ section below to install
-   additional optional bundles and for other customizations.
+   This creates a new WSL2 instance of the default Linux flavour and release, with the default
+   instance name and only the core setup bundles installed. See the `Parameters`_ section below to
+   provision your WSL2 instance with additional setup bundles and for other customizations.
 
    .. pull-quote:: \:bangbang: **IMPORTANT**
 
@@ -83,10 +92,16 @@ Parameters
      -
    * - ``-SetupArgs``
      - Arguments for the setup script ``whistle.bash``.
-     - ``"-h"``, ``"-b python3"``, ``"-u dragondive -b copy-ssh-keys"``
+     - ``"-h"``, ``"-b python3"``, ``"-u dragondive -b copy-ssh-keys,rust"``
      - ``""``
-     - This needs to be enclosed in double quotes.
-       Run with ``"'-h'"`` for the full description of the supported arguments.
+     - The argument string to ``-SetupArgs`` needs to be enclosed in double quotes.
+   * - ``-Help``
+     - Display information on how to use ``whistle`` to create and provision a new WSL2 instance.
+     -
+     -
+     - Use this information to determine the setup bundles you want to install and any other
+       customizations you want to make.
+
 
 Contributor Documentation
 -------------------------

--- a/whistle-cli.help
+++ b/whistle-cli.help
@@ -1,0 +1,25 @@
+-h, --help
+    Display this help message and exit
+
+-u, --username <username>
+    Create a local user <username> in the WSL2 instance and set it as the default user.
+    Also prompts to set the password for the user.
+
+    If not specified, the WSL2 distro name will be the default username and password.
+
+-b, --setup-bundles [bundles,...]
+    Comma-separated list of setup bundles to be executed. Some setup bundles are considered
+    core bundles and will always be executed.
+
+    Usually the setup bundles will install the respective application, some useful utilities, and
+    perform standard configurations. Additional information about specific setup bundles is
+    described below.
+
+Available setup bundles:
+    - rust
+    - python3
+    - copy-ssh-keys
+        Copies ssh keys from Windows to WSL2 and sets the correct permissions.
+    - docker [core bundle]
+    - git [core bundle]
+    - utils [core bundle]

--- a/whistle.bash
+++ b/whistle.bash
@@ -5,33 +5,8 @@ display_help()
 cat << EOF
 Usage: whistle.bash [OPTION]...
 
--h, --help
-    Display this help message and exit
-
--u, --username <username>
-    Create a local user <username> in the WSL2 instance and set it as the default user.
-    Also prompts to set the password for the user.
-
-    If not specified, the WSL2 distro name will be the default username and password.
-
--b, --setup-bundles [bundles,...]
-    Comma-separated list of setup bundles to be executed. Some setup bundles are
-    considered core bundles and will always be executed.
-
-    Usually the setup bundles will install the respective application, some useful
-    utilities, and perform standard configurations. Additional information about
-    specific setup bundles is described below.
-
-Available setup bundles:
-    - rust
-    - python3
-    - copy-ssh-keys
-        Copies ssh keys from Windows to WSL2 and sets the correct permissions.
-    - docker [core bundle]
-    - git [core bundle]
-    - utils [core bundle]
-
 EOF
+cat whistle-cli.help
 }
 
 ARGUMENTS=("$@")

--- a/whistle.ps1
+++ b/whistle.ps1
@@ -2,8 +2,8 @@
 .SYNOPSIS
     Download, create and provision an Ubuntu WSL2 instance.
 .DESCRIPTION
-    This script downloads a user-specified Ubuntu WSL2 image, then creates and
-    provisions a WSL2 instance using the downloaded image.
+    This script downloads a user-specified Ubuntu WSL2 image, then creates and provisions a WSL2
+    instance using the downloaded image.
 .PARAMETER WslDistroName
     User-chosen name for the WSL2 instance to be created.
 
@@ -16,8 +16,8 @@
     Example values: noble, jammy
     Default: noble
 .PARAMETER ReleaseTag
-    Ubuntu release tag. Available release tags are found inside the directory of the
-    specified release on the Ubuntu WSL images page.
+    Ubuntu release tag. Available release tags are found inside the directory of the specified
+    release on the Ubuntu WSL images page.
 
     Example values: current, 20241008
     Default: current
@@ -27,13 +27,15 @@
     Example values: amd64, arm64
     Default: amd64
 .PARAMETER SetupArgs
-    Arguments for the setup script `whistle.bash`.
-    Due to powershell's parsing limitations, this needs to be enclosed in _both_
-    double quotes and single quotes.
-    Use "'-h'" as the argument to see the arguments documentation.
+    Arguments for the setup script `whistle.bash`. This needs to be enclosed in double quotes.
 
-    Example values: "'-h'", "'-b python3'", "'-u dragondive -b copy-ssh-keys'"
+    Example values: "-b rust", "-u dragondive -b copy-ssh-keys,python3"
     Default: ""
+
+    Detailed help on the arguments is provided below.
+
+.PARAMETER Help
+    Show information on how to use this script and exit.
 #>
 param
 (
@@ -50,8 +52,22 @@ param
     [string]$ReleaseArch = "amd64",
 
     [Parameter(HelpMessage="Arguments for the setup script whistle.bash")]
-    [string]$SetupArgs = ""
+    [string]$SetupArgs = "",
+
+    [Parameter(HelpMessage="Show information on how to use this script and exit.")]
+    [switch]$Help = $false
 )
+
+if ($Help)
+{
+    Get-Help -Name $MyInvocation.MyCommand.Path -Detailed -ErrorAction SilentlyContinue
+    Write-Host "-----------------------------------------------------------------"
+    Write-Host "Detailed help on the arguments for the setup script whistle.bash:"
+    Write-Host "-----------------------------------------------------------------"
+    Get-Content -Path whistle-cli.help
+    Write-Host "-----------------------------------------------------------------"
+    exit 0
+}
 
 $WslUbuntuUrl = "https://cloud-images.ubuntu.com/wsl"
 $ImageName = "ubuntu-$ReleaseName-wsl-$ReleaseArch-ubuntu.rootfs.tar.gz"


### PR DESCRIPTION
Refactor the help text in `whistle.bash` into a separate text file that is now reused by both `whistle.bash` and `whistle.ps1`. This enables the users to access the help text directly from the Powershell script.

It also addresses another problem wherein even if the user specified `-h` argument to `-SetupArgs` as the current documentation suggests, it requires creating an entire new WSL2 instance to run the bash script to see the help text!

fixes: #24